### PR TITLE
Export

### DIFF
--- a/export.ts
+++ b/export.ts
@@ -1,0 +1,103 @@
+import { writeFile, readFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { glob } from "glob";
+import { mkdir } from "fs/promises";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkMdx from "remark-mdx";
+import remarkStringify from "remark-stringify";
+import { SKIP, visit } from "unist-util-visit";
+import { Root } from "mdast";
+
+const OUTPUT_DIR = "md";
+
+
+// Transform mdx, removing or simplifying parts of the tree
+function mdxToMd() {
+  const toRemove = ["mdxjsEsm", "mdxJsxFlowElement"];
+  return (tree: Root) => {
+    visit(tree, (node, index, parent) => {
+      if (node.type === "mdxJsxFlowElement") {
+        console.log(node);
+      }
+      if (toRemove.includes(node.type) && parent && typeof index === "number") {
+        parent.children.splice(index, 1);
+        return [SKIP, index];
+      }
+    });
+  };
+}
+
+async function convertMdxToMd(
+  mdxPath: string,
+  outputPath: string
+): Promise<void> {
+  // Read the MDX file
+  const mdxContent = await readFile(mdxPath, "utf-8");
+
+  // Process the MDX content
+  const markdown = await unified()
+    .use(remarkParse)
+    .use(remarkMdx)
+    .use(mdxToMd)
+    .use(remarkStringify)
+    .process(mdxContent);
+
+  // Create directory if it doesn't exist
+  await mkdir(dirname(outputPath), { recursive: true });
+
+  // Write the markdown output
+  await writeFile(outputPath, String(markdown));
+}
+
+async function main() {
+  const errors = [];
+  // Find all MDX files in the project
+  const mdxFiles = await glob("**/*.mdx", {
+    ignore: ["node_modules/**", ".next/**", "out/**", `${OUTPUT_DIR}/**`],
+  });
+
+  if (mdxFiles.length === 0) {
+    console.log("No MDX files found in the project.");
+    return;
+  }
+
+  // Create the output directory if it doesn't exist
+  await mkdir(OUTPUT_DIR, { recursive: true });
+
+  let index = 0;
+  for (const mdxPath of mdxFiles) {
+    console.log(
+      `Converting ${index + 1} of ${mdxFiles.length} files: ${mdxPath}`
+    );
+
+    // Create the output path in the output directory while preserving the directory structure
+    const relativePath = mdxPath.replace(/\.mdx$/, ".md");
+    const outputPath = join(OUTPUT_DIR, relativePath);
+
+    try {
+      await convertMdxToMd(mdxPath, outputPath);
+    } catch (e) {
+      errors.push({
+        file: mdxPath,
+        error: e,
+      });
+    }
+
+    console.log(`📝 Converted ${mdxPath} -> ${outputPath}`);
+
+    index++;
+  }
+
+  console.log(
+    `\n✨ Converted ${mdxFiles.length - errors.length} of ${mdxFiles.length
+    } MDX files to MD format in ${OUTPUT_DIR}/`
+  );
+
+  errors.forEach((error) => {
+    console.error(`❌ ${error.file}`);
+    console.error(error.error);
+  });
+}
+
+main().catch(console.error);

--- a/pages/starters/nextjs.mdx
+++ b/pages/starters/nextjs.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Unbody Next.js Starter"
-authors: [{name: "Amir Houieh", link: "https://www.linkedin.com/in/amirhouieh/", image: "amir.png"}]
 audience_group: developers
 outline: "This guide offers an overview of integrating Unbody's AI-powered features using Next.js and TypeScript. It covers the setup process, semantic search, generative search, and the technology stack used in the Unbody Next.js Starter."
 seo_tags: unbody, next.js, typescript, semantic search, generative search, tailwind css


### PR DESCRIPTION
Experimental export script to render the `mdx` docs to `md`.
Motivation: `md` docs work very well for AI-assisted programming. Initial vibe-coding tryouts with the exported docs have been promising so it seems like a good idea to invest more effort into this. A reliable conversion tool will let us update our docs to work better with AI systems and support vibe coding workflows.